### PR TITLE
ci: also run ci against PR target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 env:
@@ -222,7 +223,7 @@ jobs:
 
       - name: Comment artifact url on PR
         uses: thollander/actions-comment-pull-request@v2
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request_target' }}
         with:
           pr_number: ${{ github.event.issue.number }}
           message: |


### PR DESCRIPTION
And comment only if its the pull_request_target event. Else the action does not have the permission to comment.